### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/juankmilohst/f4496097-76d7-4e7b-94de-f89cb3353df1/b5debea0-185a-4816-a904-2d04f16bb103/_apis/work/boardbadge/6f9044d6-ff4e-4457-8758-201f2f9c8cf3)](https://dev.azure.com/juankmilohst/f4496097-76d7-4e7b-94de-f89cb3353df1/_boards/board/t/b5debea0-185a-4816-a904-2d04f16bb103/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#159](https://dev.azure.com/juankmilohst/f4496097-76d7-4e7b-94de-f89cb3353df1/_workitems/edit/159). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.