### PR TITLE
Added XmlElement reference for AccountIdentifier

### DIFF
--- a/API/DTOs/FinancialTransactions/FinancialTransactionCreateDto.cs
+++ b/API/DTOs/FinancialTransactions/FinancialTransactionCreateDto.cs
@@ -17,6 +17,7 @@ namespace FinanceManagement.API.DTOs.FinancialTransactions
         public int CategoryId { get; set; }
         public bool IsExpense { get; set; }
         public int PeriodId { get; set; }
+        [XmlElement("accountIdentifier")]
         public string? AccountIdentifier { get; set; }
 
     }


### PR DESCRIPTION
Corrected a bug where the XML does not map the AccountIdentifier attribute correctly, causing transactions created with an XML File to not include the AccountIdentifier property