### PR TITLE
Added soft delete to categories

### DIFF
--- a/API/Controllers/CategoriesController.cs
+++ b/API/Controllers/CategoriesController.cs
@@ -22,9 +22,9 @@ namespace FinanceManagement.API.Controllers
 
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<CategoryReadDto>), 200)]
-        public IActionResult GetAllCategories()
+        public IActionResult GetAllCategories(bool? deleted = null)
         {
-            IEnumerable<Category> categories = CategoriesManager.GetAllCategories();
+            IEnumerable<Category> categories = CategoriesManager.GetAllCategories(deleted);
 
             IEnumerable<CategoryReadDto> categoryReadDtos = Mapper.Map<IEnumerable<CategoryReadDto>>(categories);
 

--- a/API/DTOs/Categories/CategoryReadDto.cs
+++ b/API/DTOs/Categories/CategoryReadDto.cs
@@ -5,6 +5,7 @@
         public int Id { get; set; }
         public string? Name { get; set; }
         public int Percentage { get; set; }
+        public bool Deleted { get; set; }
 
     }
 }

--- a/API/DTOs/FinancialTransactions/FinancialTransactionReadDto.cs
+++ b/API/DTOs/FinancialTransactions/FinancialTransactionReadDto.cs
@@ -1,4 +1,6 @@
-﻿namespace FinanceManagement.API.DTOs.FinancialTransactions
+﻿using FinanceManagement.API.DTOs.Categories;
+
+namespace FinanceManagement.API.DTOs.FinancialTransactions
 {
     public class FinancialTransactionReadDto
     {
@@ -10,5 +12,6 @@
         public bool IsExpense { get; set; }
         public int PeriodId { get; set; }
         public string? AccountIdentifier { get; set; }
+        public required CategoryReadDto Category {get; set;}
     }
 }

--- a/Core/Entities/Category.cs
+++ b/Core/Entities/Category.cs
@@ -4,10 +4,11 @@ using System.Text;
 
 namespace FinanceManagement.Core.Entities
 {
-    public class Category: BaseEntity
+    public class Category : BaseEntity
     {
         public string? Name { get; set; }
         public int Percentage { get; set; }
+        public bool Deleted { get; set; }
         public ICollection<FinancialTransaction>? FinancialTransactions { get; set; }
     }
 }

--- a/Core/Managers/ICategoriesManager.cs
+++ b/Core/Managers/ICategoriesManager.cs
@@ -7,7 +7,7 @@ namespace FinanceManagement.Core.Managers
 {
     public interface ICategoriesManager
     {
-        IEnumerable<Category> GetAllCategories();
+        IEnumerable<Category> GetAllCategories(bool? deleted = null);
         void AddCategory(Category category);
         Category GetCategoryById(int id);
         void UpdateCategory(Category category);

--- a/Core/Managers/Implementations/CategoriesManager.cs
+++ b/Core/Managers/Implementations/CategoriesManager.cs
@@ -18,13 +18,24 @@ namespace FinanceManagement.Core.Managers.Implementations
             UnitOfWork = unitOfWork;
         }
 
-        public IEnumerable<Category> GetAllCategories()
+        public IEnumerable<Category> GetAllCategories(bool? deleted = null)
         {
 
 
             IRepository<Category> categoriesRepository = UnitOfWork.GetRepository<Category>();
 
-            IEnumerable<Category> categories = categoriesRepository.GetAll();
+            IEnumerable<Category> categories;
+
+            if (deleted != null)
+            {
+                categories = categoriesRepository.GetAll(category => category.Deleted == deleted);
+            }
+            else
+            {
+                categories = categoriesRepository.GetAll();
+            }
+
+
 
             return categories;
 

--- a/Core/Managers/Implementations/CategoriesManager.cs
+++ b/Core/Managers/Implementations/CategoriesManager.cs
@@ -67,7 +67,11 @@ namespace FinanceManagement.Core.Managers.Implementations
 
             IRepository<Category> categoriesRepository = UnitOfWork.GetRepository<Category>();
 
-            categoriesRepository.DeleteById(id);
+            Category categoryToDelete = categoriesRepository.GetById(id);
+
+            categoryToDelete.Deleted = true;
+
+            categoriesRepository.Update(categoryToDelete);
 
             UnitOfWork.SaveChanges();
 

--- a/Core/Managers/Implementations/FinancialTransactionsManager.cs
+++ b/Core/Managers/Implementations/FinancialTransactionsManager.cs
@@ -50,7 +50,7 @@ namespace FinanceManagement.Core.Managers.Implementations
         {
 
             IRepository<FinancialTransaction> financialTransactionsRepository = UnitOfWork.GetRepository<FinancialTransaction>();
-            return financialTransactionsRepository.GetAll();
+            return financialTransactionsRepository.GetAll(includeProperties: "Category");
 
 
         }

--- a/DataAccess/Migrations/20250125034849_AddCategorySoftDelete.Designer.cs
+++ b/DataAccess/Migrations/20250125034849_AddCategorySoftDelete.Designer.cs
@@ -4,6 +4,7 @@ using FinanceManagement.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FinanceManagement.DataAccess.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20250125034849_AddCategorySoftDelete")]
+    partial class AddCategorySoftDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DataAccess/Migrations/20250125034849_AddCategorySoftDelete.cs
+++ b/DataAccess/Migrations/20250125034849_AddCategorySoftDelete.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinanceManagement.DataAccess.Migrations
+{
+    public partial class AddCategorySoftDelete : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Deleted",
+                table: "Categories",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Deleted",
+                table: "Categories");
+        }
+    }
+}

--- a/Tests/FinancialTransactionsManagerTests.cs
+++ b/Tests/FinancialTransactionsManagerTests.cs
@@ -120,7 +120,9 @@ namespace FinanceManagement.Tests
             //Setup
             List<FinancialTransaction> mockFinancialTransactionsDatabase = new List<FinancialTransaction>();
             Mock<IRepository<FinancialTransaction>> mockFinancialTransactionsRepository = new Mock<IRepository<FinancialTransaction>>();
-            mockFinancialTransactionsRepository.Setup(repository => repository.GetAll(null, null, "")).Returns(mockFinancialTransactionsDatabase);
+            mockFinancialTransactionsRepository.Setup(repository => repository.GetAll(It.IsAny<Expression<Func<FinancialTransaction, bool>>>(),
+            It.IsAny<Func<IQueryable<FinancialTransaction>, IOrderedQueryable<FinancialTransaction>>>(),
+            It.IsAny<string>())).Returns(mockFinancialTransactionsDatabase);
             Mock<IUnitOfWork> mockUnitOfWork = new Mock<IUnitOfWork>();
             mockUnitOfWork.Setup(unitOfWork => unitOfWork.GetRepository<FinancialTransaction>()).Returns(mockFinancialTransactionsRepository.Object);
             FinancialTransactionsManager financialTransactionsManager = new FinancialTransactionsManager(mockUnitOfWork.Object);
@@ -132,14 +134,26 @@ namespace FinanceManagement.Tests
                 Id = 1,
                 Description = "Test Transaction 1",
                 IsExpense = true,
-                Value = 1000
+                Value = 1000,
+                CategoryId = 1,
+                Category = new Category{
+                    Id = 1,
+                    Deleted = false,
+                    Name = "Test Category 1"
+                }
             });
             mockFinancialTransactionsDatabase.Add(new FinancialTransaction
             {
                 Id = 2,
                 Description = "Test Transaction 2",
                 IsExpense = false,
-                Value = 2500
+                Value = 2500,
+                CategoryId = 2,
+                Category = new Category{
+                    Id = 2,
+                    Deleted = true,
+                    Name = "Test Category 2"
+                }
             });
 
             //Act


### PR DESCRIPTION
Modified delete category service behaviour so that it soft-deletes de category instead of completely removing it from database. Also added ability to filter categories by the deleted field, and included the category element on the Get All Financial Transactions service so that the category associated can be used by the frontend.

[AB#340](https://dev.azure.com/juankmilohst/f4496097-76d7-4e7b-94de-f89cb3353df1/_workitems/edit/340)